### PR TITLE
Added TCVoltsToTemp function to LJM_FUNCTIONS list

### DIFF
--- a/lib/ljm_functions.js
+++ b/lib/ljm_functions.js
@@ -167,6 +167,16 @@ LJM_FUNCTIONS.LJM_ErrorToString = {
 	]
 };
 
+LJM_FUNCTIONS.LJM_TCVoltsToTemp = {
+	'ret': [{'LJM_ERROR_RETURN': 	'int'}],
+	'args': [
+		{'TCType': 					'int'},
+		{'TCVolts': 				'double'},
+		{'CJTempK': 				'double'},
+		{'pTCTempK': 				'double*'},
+	]
+};
+
 LJM_FUNCTIONS.LJM_LoadConstants = {
 	'ret': [{'LJM_ERROR_RETURN': 	'int'}],
 	'args': []						//No Args


### PR DESCRIPTION
Added the LJM utility function [TCVoltsToTemp](https://labjack.com/support/software/api/ljm/function-reference/utility/ljmtcvoltstotemp) to the list of supported LJMFunctions

(Re-submitting https://github.com/chrisJohn404/ljm-ffi/pull/8, but targeted at the specific branch of the change)